### PR TITLE
Cleaned up loss implementation and usage

### DIFF
--- a/src/losses.py
+++ b/src/losses.py
@@ -111,11 +111,13 @@ class TempCombLoss(nn.Module):
 	
 	def forward(
 		self,
-		mean: Tensor, one_over_alpha: Tensor, beta: Tensor, target: Tensor,
+		mean: Tensor, one_over_alpha: Tensor, beta: Tensor, target1: Tensor, target2: Tensor,
 		T1: float, T2: float
 	):
-		l1 = self.L_l1(mean, target)
-		l2 = self.L_GenGauss(mean, one_over_alpha, beta, target)
+		##target1 is the base model output for identity mapping
+		##target2 is the ground truth for the GenGauss loss
+		l1 = self.L_l1(mean, target1)
+		l2 = self.L_GenGauss(mean, one_over_alpha, beta, target2)
 		l = T1*l1 + T2*l2
 
 		return l

--- a/src/utils.py
+++ b/src/utils.py
@@ -600,10 +600,7 @@ def train_BayesCap(
 				xSRC_mu, xSRC_alpha, xSRC_beta = NetC(xSR)
 				# print(xSRC_alpha) 
 				optimizer.zero_grad()
-				if task == 'depth':
-					loss = Cri(xSRC_mu, xSRC_alpha, xSRC_beta, xSR, T1=T1, T2=T2)
-				else:
-					loss = Cri(xSRC_mu, xSRC_alpha, xSRC_beta, xHR, T1=T1, T2=T2)
+				loss = Cri(xSRC_mu, xSRC_alpha, xSRC_beta, xSR, xHR, T1=T1,T2=T2)
 				# print(loss)
 				loss.backward()
 				optimizer.step()


### PR DESCRIPTION
I think I have fixed the issue mentioned in #2
The `TempCombLoss` takes `target1` (the base model output) and  `target2` (the ground truth) and these are applied appropriately. 